### PR TITLE
feat: implement AI-generated conversation title

### DIFF
--- a/components/dashboard/ask-qlever/ai-prompt.tsx
+++ b/components/dashboard/ask-qlever/ai-prompt.tsx
@@ -43,11 +43,17 @@ const researchModeAndSuggestionItems: ResearchModeAndSuggestionItem[] = [
     disabled: true,
   },
   {
-    label: "DeepSearch",
-    icon: <Icons.search className="size-4" />,
-    tooltip: "Advanced search and reasoning",
+    label: "Search",
+    icon: <Icons.globe className="size-4" />,
+    tooltip: "Search the web",
     disabled: true,
   },
+  // {
+  //   label: "DeepSearch",
+  //   icon: <Icons.search className="size-4" />,
+  //   tooltip: "Advanced search and reasoning",
+  //   disabled: true,
+  // },
   {
     label: "Think",
     icon: <Icons.lightbulb className="size-4" />,

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -48,6 +48,7 @@ import {
   Download,
   Sparkles,
   MessageSquare,
+  Globe,
   type Icon as LucideIcon,
 } from "lucide-react";
 
@@ -101,6 +102,7 @@ export const Icons = {
   download: Download,
   sparkles: Sparkles,
   message: MessageSquare,
+  globe: Globe,
 } as const;
 
 export const GoogleIcon = (props: SVGProps<SVGSVGElement>) => (


### PR DESCRIPTION
feat: implement AI-generated conversation title.

- the title is a summary of the user's message;
- not more than 80 characters long;
- based on the first message a user begins a conversation with.